### PR TITLE
Create new class method for `create_list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Benchmark ruby client which wraper the sameple the benchmark provide [here](http
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'benchmark_client'
+gem 'benchmark_client', git: 'git@github.com:resumecompanion/benchmark_client.git'
+
 ```
 
 And then execute:
@@ -22,8 +23,8 @@ Or install it yourself as:
 
 ### Config the credential 
 
+```ruby
 
-    ```
     # in initializer/benchmark_client.rb
     
     BenchmarkClient.configure do |config| 
@@ -32,9 +33,13 @@ Or install it yourself as:
       config.api_url = 'url_of_api_version'
       config.default_list_name = 'the list name you will create in benchmark'
     end
-    ```
+
+```
+
 
 ### Create list 
+
+When sync user's data to benchmark, you need to create a list name first
 
 
     ```

--- a/lib/benchmark_client/base.rb
+++ b/lib/benchmark_client/base.rb
@@ -7,6 +7,10 @@ module BenchmarkClient
       new.update(*args)
     end
 
+    def self.create_list(list_name = nil)
+      new.create_list(list_name)
+    end
+
     def initialize
       setup_remote_server
     end

--- a/lib/benchmark_client/version.rb
+++ b/lib/benchmark_client/version.rb
@@ -1,3 +1,3 @@
 module BenchmarkClient
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Bug

In documentation we have `create_list` method so we can use it
directly without initialize the instance then call it

Like

`BenchmarkClient::Base.new.create_list`

We chnage to `BenchmarkClient::Base.create_list`